### PR TITLE
scan: Retry getting user ID if getlogin() does not work

### DIFF
--- a/py4syn/utils/scan.py
+++ b/py4syn/utils/scan.py
@@ -2,6 +2,7 @@ import collections
 import datetime
 from enum import Enum
 import os
+import pwd
 
 import numpy
 
@@ -894,7 +895,15 @@ class Scan(object):
             if(FILE_WRITER is not None):
                 FILE_WRITER.setStartDate(self.__startTimestamp)
                 FILE_WRITER.insertComment(SCAN_COMMENT)
-                FILE_WRITER.setUsername(os.getlogin())
+
+                try:
+                    user = os.getlogin()
+                except FileNotFoundError:
+                    user = os.environ.get('LOGNAME') or os.environ.get('USERNAME')
+                    if not user:
+                        user = pwd.getpwuid(os.getuid())[0]
+
+                FILE_WRITER.setUsername(user)
                 FILE_WRITER.setCommand(SCAN_CMD)
                 FILE_WRITER.setDataSize(self.getNumberOfPoints())
 


### PR DESCRIPTION
Using getlogin() is deprecated, so use the recommended way described in
the python standard library:

	"For most purposes, it is more useful to use the environment
	variables LOGNAME or USERNAME to find out who the user is, or
	pwd.getpwuid(os.getuid())[0] to get the login name of the
	current real user id."

References:
https://docs.python.org/3/library/os.html#os.getlogin
https://stackoverflow.com/a/4785195