### PR TITLE
Added a new field to DefaultWriter header (#M), following SPEC specifications

### DIFF
--- a/py4syn/writing/DefaultWriter.py
+++ b/py4syn/writing/DefaultWriter.py
@@ -41,6 +41,8 @@ class DefaultWriter(FileWriter):
             
         r += "#S 1 " + self.getCommand() + "\n"
         r += "#D " + "{0:%a %b %d %H:%M:%S %Y}".format(self.getStartDate()) + "\n"
+
+        r += "#M " + str(self.getDataSize()) + "\n"
         
         numberOfFields = len(self.getDevices()) + len(self.getSignals())
         r += "#N " + str(numberOfFields) + "\n"     


### PR DESCRIPTION
Added a new header field, #M <number_of_lines>, in the output for DefaultWriter.
Following the specification of SPEC standard data-file format (see page 192 of https://certif.com/downloads/css_docs/spec_man.pdf).
This field helps reading the file when a scan is writing in synchronous mode because the reader knows how many lines to expect before hitting the end of the scan.