### PR TITLE
Fix closing parentheses in VortexXspress3Class

### DIFF
--- a/py4syn/epics/VortexXspress3Class.py
+++ b/py4syn/epics/VortexXspress3Class.py
@@ -57,7 +57,7 @@ class VortexXspress3(StandardDevice, ICountable):
         # Channels 1-4
         for i in range(1, 5):
             for j in range(1, 5):            
-               self.pvMcaCounters.append(PV('{}:C{}_ROI{}:Value_RBV'.format(pv, j, i))
+               self.pvMcaCounters.append(PV('{}:C{}_ROI{}:Value_RBV'.format(pv, j, i)))
 
         self.pvClear.put(1, wait=True)
         


### PR DESCRIPTION
Hi,

This is just a small fix on Vortex class. There was a missing parentheses in it, which was leading to syntax error.

Thanks,

Laís