### PR TITLE
wa() function prints sorted motors

### DIFF
--- a/py4syn/utils/motor.py
+++ b/py4syn/utils/motor.py
@@ -467,7 +467,7 @@ def wa():
     data[0].append("User:")
     data[0].append("Dial:")
     i = 1
-    for mtr in py4syn.mtrDB:
+    for mtr in sorted(py4syn.mtrDB):
         data[i].append(mtr)
         data[i].append(str ("%5.4f"%py4syn.mtrDB[mtr].getRealPosition()))
         data[i].append(str ("%5.4f"%py4syn.mtrDB[mtr].getDialRealPosition()))


### PR DESCRIPTION
When showing the motors' position, the wa() function gets the motors from the mtrDB dictionary. However, if the mtrDB is not ordered, the wa() function will print the motors unordered as well.

This pull request changes the wa() function, so instead of getting the motors keys (which is the motor name) from the dictionary iterator list in the for loop, it orders the dictionary iterator list first, and then loops through it, printing the motors ordered by their names.

The purpose of that change is to increase the readability of the wa() output. When wa() is used with lots of motors registered in the mtrDB, it gets hard to find some specific motors. Example:

Let us use the wa() and find the values of the MonoT1 and MonoT2 motors.
```
Motor:                User:                Dial:
FotodiodoDeQuadranteVertical               4.0000              60.4919
              energy            2520.6064               0.0000
FotodiodoDoMonocromador              11.6216               1.1329
    DETFLUORESCENCIA              10.0000              20.0012
              aero_y               0.0000               0.0000
          BaseSaidaY              -1.7953              -1.7953
        BaseEntradaX              -4.8027              -4.8027
        MonoVertical            1500.0100            1500.0100
                SIM1              10.0000              10.0000
           MICOPTICO               2.0000             -63.6255
     NiveladorSaidaX            1408.3130            1408.3130
FendaPreMonoInferior             -79.9998              97.8927
ManipuladorBobinaEixoTheta             -90.0000               0.0000
              MonoT1              13.7885              13.7885
               MESAX              -0.5500              -1.8819
    FendaPreMonoAnel               0.0000               0.0000
    FendaPosMonoHall              -6.0000             -23.6884
 FendaPreEspelhoAnel              25.0000              16.9420
             MonoRo1               0.0000               0.0000
    FendaPreMonoHall               0.0000               0.0000
    FendaPosMonoAnel               2.0000              17.9369
FendaPosMonoInferior              -2.0000               2.0781
                SIM3               0.0000               0.0000
             MonoPi2              -0.1250              -0.1250
 FendaPreEspelhoHall             -25.0000              22.4158
          aero_theta               0.0000               0.0000
               MESAZ              -3.7376              31.7566
FendaPreEspelhoInferior              -0.5000             -22.8059
               MESAY              -4.7000              -1.1224
      CorrenteZeroI0              48.0000             -66.8479
                SIM2               0.0000               0.0000
NiveladorEntradaHallY            1398.6679            1398.6679
             MonoRo2               0.2300               0.2300
                SIM5               0.0000               0.0000
               PITCH              -0.3303              76.3798
          ThetaBragg              52.9182              52.9182
NiveladorEntradaAnelZ            1398.7175            1398.7175
      MonoHorizontal              49.0040              49.0040
              MonoT2              18.2435              18.2435
                SIM4               0.0000               0.0000
FendaPreMonoSuperior              39.5000               1.4750
                 YAW              -0.9900             -12.1586
FendaPreEspelhoSuperior               0.5000             -28.1687
ManipuladorBobinaEixoZ              41.3349               0.0000
                 PZT              22.1950              22.1950
FendaPosMonoSuperior               2.5000              -0.6655
              aero_x               0.0000               0.0000
FotodiodoDeQuadranteHorizontal               0.0000               0.0000
```

If the output shows the motors ordered alphabetically, it becomes easier to find any desired motor:
